### PR TITLE
changed how profile_pic is stored and displayed

### DIFF
--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -38,9 +38,7 @@ class RegisterController extends Controller
         // otherwise, set profile pic to generic picture in public>images
         if(isset($attributes['profile_pic'])){
             $attributes['profile_pic'] = request()->file('profile_pic')->store('profile_pics');
-        } else {
-            $attributes['profile_pic'] = "profile_pics/generic_profile_pic.png";
-        }
+        } 
 
         // create the user with validated attributes
         $user = User::create($attributes);

--- a/resources/views/components/post-card.blade.php
+++ b/resources/views/components/post-card.blade.php
@@ -1,7 +1,6 @@
 @props(['post'])
 
-<article
-    {{ $attributes->merge(['class' => "transition-colors duration-300 hover:bg-gray-100 border border-black border-opacity-0 hover:border-opacity-5 rounded-xl" ]) }} > 
+<article {{ $attributes->merge(['class' => "transition-colors duration-300 hover:bg-gray-100 border border-black border-opacity-0 hover:border-opacity-5 rounded-xl" ]) }}>
     <div class="py-6 px-5">
         <div>
             <img src="{{ asset('storage/' . $post->thumbnail) }}" alt="Blog Post illustration" class="rounded-xl">
@@ -27,22 +26,25 @@
             </header>
 
             <div class="text-sm mt-4 space-y-4">
-                    {!! $post->excerpt !!}
+                {!! $post->excerpt !!}
             </div>
 
             <footer class="flex justify-between items-center mt-8">
                 <div class="flex items-center text-sm">
-                    <!-- <img src="/images/lary-avatar.svg" alt="Lary avatar"> -->
-                    <img src="{{ asset('storage/' . $post->author->profile_pic) }}" alt="Profile Picture" height="55" width="55" style="border-radius:20%">
+
+                    <!-- change -->
+                    <img src="{{ isset($post->author->profile_pic) ? 
+                     asset('storage/' . $post->author->profile_pic) :
+                     '/images/generic_profile_pic.png' }}" alt="" width="60" height="60" class="rounded-xl">
+                    <!-- end change -->
+
                     <div class="ml-3">
                         <h5 class="font-bold"><a href="/?author={{$post->author->username}}">{{$post->author->name}}</a></h5>
                     </div>
                 </div>
 
                 <div>
-                    <a href="/posts/{{$post->slug}}"
-                        class="transition-colors duration-300 text-xs font-semibold bg-gray-200 hover:bg-gray-300 rounded-full py-2 px-8"
-                    >Read More</a>
+                    <a href="/posts/{{$post->slug}}" class="transition-colors duration-300 text-xs font-semibold bg-gray-200 hover:bg-gray-300 rounded-full py-2 px-8">Read More</a>
                 </div>
             </footer>
         </div>

--- a/resources/views/components/post-comment.blade.php
+++ b/resources/views/components/post-comment.blade.php
@@ -4,14 +4,19 @@
 
     <div class="flex-shrink-0">
         <!-- <img src="https://i.pravatar.cc/60?u={{ $comment->user_id }}" alt="" width="60" height="60" class="rounded-xl"> -->
-        <img src="{{ asset('storage/' . $comment->author->profile_pic)  }}" alt="" width="60" height="60" class="rounded-xl">
+
+        <!-- change -->
+        <img src="{{ isset($comment->author->profile_pic) ? 
+                     asset('storage/' . $comment->author->profile_pic) :
+                     '/images/generic_profile_pic.png' }}" alt="" width="60" height="60" class="rounded-xl">
+        <!-- end change -->
     </div>
 
     <div>
         <header class="mb-4">
             <h3 class="font-bold">{{$comment->author->username}}</h3>
             <p class="text-xs">
-                Posted 
+                Posted
                 <time>{{$comment->created_at->diffForHumans()}}</time>
             </p>
         </header>

--- a/resources/views/components/post-featured-card.blade.php
+++ b/resources/views/components/post-featured-card.blade.php
@@ -31,8 +31,13 @@
 
             <footer class="flex justify-between items-center mt-8">
                 <div class="flex items-center text-sm">
-                    <!-- <img src="/images/lary-avatar.svg" alt="Lary avatar"> -->
-                    <img src="{{ asset('storage/' . $post->author->profile_pic) }}" alt="Profile Picture" height="55" width="55" style="border-radius:20%">
+
+                    <!-- change -->
+                    <img src="{{ isset($post->author->profile_pic) ? 
+                     asset('storage/' . $post->author->profile_pic) :
+                     '/images/generic_profile_pic.png' }}" alt="" width="60" height="60" class="rounded-xl">
+                    <!-- end change -->
+
                     <div class="ml-3">
                         <h5 class="font-bold"><a href="/?author={{$post->author->username}}">{{$post->author->name}}</a></h5>
                     </div>

--- a/resources/views/posts/_add-comment-form.blade.php
+++ b/resources/views/posts/_add-comment-form.blade.php
@@ -1,30 +1,36 @@
 @auth
-    <x-panel>
-        <form method="POST" action="/posts/{{$post->slug}}/comments">
-            @csrf
+<x-panel>
+    <form method="POST" action="/posts/{{$post->slug}}/comments">
+        @csrf
 
-            <header class="flex items-center">
-                <!-- <img src="https://i.pravatar.cc/60?u={{ auth()->id() }}" alt="" width="40" height="40" class="rounded-full"> -->
-                <img src="{{ asset('storage/' . auth()->user()->profile_pic) }}"  alt="Profile Picture" width="40" height="40" class="rounded-full"> 
-                <h2 class="ml-4"> Join the discussion. </h2>
-            </header>
+        <header class="flex items-center">
+            <!-- <img src="https://i.pravatar.cc/60?u={{ auth()->id() }}" alt="" width="40" height="40" class="rounded-full"> -->
 
-            <div class="mt-6">
-                <textarea name="body" class="w-full text-sm focus:outline-none focus:ring" rows="5" placeholder="Type your comment here." required></textarea>
+            <!-- change -->
+            <img src="{{ isset(auth()->user()->profile_pic) ? 
+                         asset('storage/' . auth()->user()->profile_pic) : 
+                         '/images/generic_profile_pic.png'  }}" alt="" width="60" height="60" class="rounded-xl">
+            <!-- end change -->
 
-                @error('body')
-                    <span class="text-red-500 text-xs"> {{ $message }} </span>
-                @enderror
-            </div>
+            <h2 class="ml-4"> Join the discussion. </h2>
+        </header>
 
-            <div class="flex justify-end mt-6 pt-6">
-                <x-form.button>Post</x-form.button>
-            </div>
+        <div class="mt-6">
+            <textarea name="body" class="w-full text-sm focus:outline-none focus:ring" rows="5" placeholder="Type your comment here." required></textarea>
 
-        </form>
-    </x-panel> 
-@else 
-    <p class="font-semibold">
-        <a href="/register" class="hover:underline">Register</a> or <a href="/login" class="hover:underline">login</a> to leave a comment.
-    </p>   
+            @error('body')
+            <span class="text-red-500 text-xs"> {{ $message }} </span>
+            @enderror
+        </div>
+
+        <div class="flex justify-end mt-6 pt-6">
+            <x-form.button>Post</x-form.button>
+        </div>
+
+    </form>
+</x-panel>
+@else
+<p class="font-semibold">
+    <a href="/register" class="hover:underline">Register</a> or <a href="/login" class="hover:underline">login</a> to leave a comment.
+</p>
 @endauth

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -10,8 +10,13 @@
                     </p>
 
                     <div class="flex items-center lg:justify-center text-sm mt-4">
-                        <!-- <img src="/images/lary-avatar.svg" alt="Lary avatar"> -->
-                        <img src="{{ asset('storage/' . $post->author->profile_pic) }}" alt="Profile Picture" height="55" width="55" style="border-radius:20%">
+
+                        <!-- change -->
+                        <img src="{{ isset($post->author->profile_pic) ? 
+                                     asset('storage/' . $post->author->profile_pic) :
+                                     '/images/generic_profile_pic.png' }}" alt="" width="60" height="60" class="rounded-xl">
+                        <!-- end change -->
+
                         <div class="ml-3 text-left">
                             <h5 class="font-bold"><a href="/?author={{$post->author->username}}">{{$post->author->name}}</a></h5>
                         </div>
@@ -20,14 +25,12 @@
 
                 <div class="col-span-8">
                     <div class="hidden lg:flex justify-between mb-6">
-                        <a href="{{ session('blog_url') }}"
-                            class="transition-colors duration-300 relative inline-flex items-center text-lg hover:text-blue-500">
+                        <a href="{{ session('blog_url') }}" class="transition-colors duration-300 relative inline-flex items-center text-lg hover:text-blue-500">
                             <svg width="22" height="22" viewBox="0 0 22 22" class="mr-2">
                                 <g fill="none" fill-rule="evenodd">
                                     <path stroke="#000" stroke-opacity=".012" stroke-width=".5" d="M21 1v20.16H.84V1z">
                                     </path>
-                                    <path class="fill-current"
-                                        d="M13.854 7.224l-3.847 3.856 3.847 3.856-1.184 1.184-5.04-5.04 5.04-5.04z">
+                                    <path class="fill-current" d="M13.854 7.224l-3.847 3.856 3.847 3.856-1.184 1.184-5.04-5.04 5.04-5.04z">
                                     </path>
                                 </g>
                             </svg>
@@ -53,11 +56,11 @@
                     @include('posts._add-comment-form')
 
                     @foreach($post->comment as $comment)
-                        <x-post-comment :comment='$comment'/>
+                    <x-post-comment :comment='$comment' />
                     @endforeach
-                </section> 
+                </section>
 
             </article>
         </main>
-    </section>   
+    </section>
 </x-layout>


### PR DESCRIPTION
Change how user profile_pic is store in RegisterController and how it is accessed by the views.

    I deleted the else clause inside the store function in RegisterController. The else clause was used to store the path to the generic_profile_pic, which was manually stored in the storage/app/public/profile_pics/ folder when debugging. This file is deleted when application is in production, so it was necessary to change the way to access the generic profile picture. 
    The solution I decided to go with was to simply not store anything into profile_pic if the user did not input anything, and instead, reference the generic_profile_pic image I placed in the public/images/ folder in the views. Inside of each view that displays the user profile_pic, I added a bit of logic to check first if the user has a profile picture in the database and, if not, it provides the path to the generic_profile_pic inside of the public/images folder.     