### PR TITLE
took off mx-auto from setting.blade.php view, which regulated the adm…

### DIFF
--- a/resources/views/components/setting.blade.php
+++ b/resources/views/components/setting.blade.php
@@ -1,6 +1,6 @@
 @props(['heading'])
 
-<section class="py-8 max-w-5xl mx-auto">
+<section class="py-8 max-w-5xl">
     <h1 class="text-lg font-bold mb-8 lg:ml-0 ml-2 pb-2 border-b">
         {{ $heading }}
     </h1>


### PR DESCRIPTION
the mx-auto class was preventing the about.edit view from expanding in both mobile and desktop views, so I just took it off. The setting.blade.php view is the base of all admin views, so this change technically affects all admin views, but it had no visual effect on any other view besides the admin.about.edit view. 