### PR TITLE
added email attribute to UserFactory and fixed the flash message bug

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -20,6 +20,7 @@ class UserFactory extends Factory
         return [
             'name' => $this->faker->name(),
             'username' => $this->faker->unique()->userName(),
+            'email' => $this->faker->unique()->email(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),
         ];

--- a/resources/views/livewire/delete-user.blade.php
+++ b/resources/views/livewire/delete-user.blade.php
@@ -64,7 +64,7 @@
                                                         </span>
                                                     </x-slot>
 
-                                                    @foreach ( $user->likes->unique('likeable_id') as $like)
+                                                    @foreach ($user->likes->unique('likeable_id') as $like)
                                                         <p class="block text-left px-3 text-sm leading-6">
                                                             {{ $like->post->title }}
                                                         </p>
@@ -174,12 +174,16 @@
         </div>
     </x-setting>
 
-    @if ($users->count())
-        <x-modal-delete wire:model.defer="modalDelete" :object="$user">usuário
-            <strong>({{ $currentUser->username }})</strong>
-        </x-modal-delete>
-    @endif
+    <div>
+        @if ($users->count())
+            <x-modal-delete wire:model.defer="modalDelete" :object="$user">usuário
+                <strong>({{ $currentUser->username }})</strong>
+            </x-modal-delete>
+        @endif
+    </div>
 
-    <x-flash />
+    <div>
+        <x-flash />
+    </div>
 
 </div>


### PR DESCRIPTION
Apparently livewire was the cause of two of the main bugs I did not know how to fix. I fixed the comment problem in the previous commit and I fixed the flash message not disappearing problem in this commit. The flash message problem occurred whenever I deleted the last user and the success flash message would show up, but instead of leaving after 3500ms it would just stay in the page until refreshed. But by wrapping the flash message (which was a blade directive!) in a div, it fixed the problem! Now I just have to do the same for in my manage-posts view, because I forgot, so that will be the next commit! 