### PR TITLE
resize post thumbnail images when creating or editing a post

### DIFF
--- a/app/Http/Livewire/CreatePost.php
+++ b/app/Http/Livewire/CreatePost.php
@@ -5,6 +5,7 @@ namespace App\Http\Livewire;
 use App\Models\Post;
 use Livewire\Component;
 use Livewire\WithFileUploads;
+use Intervention\Image\Facades\Image;
 
 class CreatePost extends Component
 {
@@ -40,7 +41,7 @@ class CreatePost extends Component
                 $this->tempUrl = null;
             }
         }
-        
+
         $this->validateOnly($propertyName);
     }
 
@@ -50,8 +51,16 @@ class CreatePost extends Component
 
         // append the user_id value to the $attributes array so that a new Post instance can be created
         $attributes['user_id'] = auth()->id();
+
+        // image sanitation
+        $image = Image::make($this->thumbnail);
+        $image->resize(400, 400);
+        
+        $path = config('filesystems.disks.public.root') . "/thumbnails/" . $this->thumbnail->hashName();
+        $image->save($path);
+
         // store thumbnail file path in $attributes array
-        $attributes['thumbnail'] = $this->thumbnail->store('thumbnails');
+        $attributes['thumbnail'] = '/thumbnails/' . $this->thumbnail->hashName();
         // instantiate a new post
         $post = Post::create($attributes);
 

--- a/app/Http/Livewire/EditPostForm.php
+++ b/app/Http/Livewire/EditPostForm.php
@@ -5,6 +5,7 @@ namespace App\Http\Livewire;
 use App\Models\Post;
 use Livewire\Component;
 use Livewire\WithFileUploads;
+use Intervention\Image\Facades\Image;
 
 class EditPostForm extends Component
 {
@@ -74,7 +75,15 @@ class EditPostForm extends Component
         $attributes = $this->validate();
 
         if (isset($attributes['thumbnail'])) {
-            $attributes['thumbnail'] = $this->thumbnail->store('thumbnails');
+            // image sanitation
+            $image = Image::make($this->thumbnail);
+            $image->resize(400, 400);
+
+            $path = config('filesystems.disks.public.root') . "/thumbnails/" . $this->thumbnail->hashName();
+            $image->save($path);
+
+            // store thumbnail file path in $attributes array
+            $attributes['thumbnail'] = '/thumbnails/' . $this->thumbnail->hashName();
         }
 
         // this 'update' method is not the same as the one created, it belogs to the model class

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,7 +38,7 @@ class AppServiceProvider extends ServiceProvider
     {
         Gate::define('admin', function(User $user){
 
-            return in_array($user->username, ['jessicaszklarz']);
+            return in_array($user->username, ['jessicaszklarz', 'phpaivamotta']);
 
         });
 

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": "^8.0.2",
         "guzzlehttp/guzzle": "^7.2",
+        "intervention/image": "^2.7",
         "itsgoingd/clockwork": "^5.1",
         "jorenvanhocht/laravel-share": "^4.2",
         "laravel/framework": "^9.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcbb5d776a78e7b8f97a8b0c4d865b02",
+    "content-hash": "3d640510094951ecb73875dcbabcba06",
     "packages": [
         {
             "name": "brick/math",
@@ -892,6 +892,90 @@
                 }
             ],
             "time": "2022-06-20T21:43:11+00:00"
+        },
+        {
+            "name": "intervention/image",
+            "version": "2.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "04be355f8d6734c826045d02a1079ad658322dad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/04be355f8d6734c826045d02a1079ad658322dad",
+                "reference": "04be355f8d6734c826045d02a1079ad658322dad",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "guzzlehttp/psr7": "~1.1 || ^2.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.2",
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^7.5.15"
+            },
+            "suggest": {
+                "ext-gd": "to use GD library based image processing.",
+                "ext-imagick": "to use Imagick based image processing.",
+                "intervention/imagecache": "Caching extension for the Intervention Image library"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Intervention\\Image\\ImageServiceProvider"
+                    ],
+                    "aliases": {
+                        "Image": "Intervention\\Image\\Facades\\Image"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src/Intervention/Image"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io/"
+                }
+            ],
+            "description": "Image handling and manipulation library with support for Laravel integration",
+            "homepage": "http://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "laravel",
+                "thumbnail",
+                "watermark"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/image/issues",
+                "source": "https://github.com/Intervention/image/tree/2.7.2"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-05-21T17:30:32+00:00"
         },
         {
             "name": "itsgoingd/clockwork",

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -32,7 +32,7 @@
 </head>
 
 <body style="font-family: Open Sans, sans-serif">
-    <section class="lg:px-6 pt-4 lg:py-8 flex flex-col min-h-screen">
+    <section class="flex flex-col lg:px-6 lg:py-8 max-w-7xl min-h-screen mx-auto pt-4">
         <nav class="lg:flex lg:justify-between lg:items-center">
             <div class="w-14">
                 <a href="/">

--- a/resources/views/components/post-card.blade.php
+++ b/resources/views/components/post-card.blade.php
@@ -5,7 +5,7 @@
     <div class="lg:py-6 lg:px-5">
         <div>
             <a href="/posts/{{ $post->slug  }}">
-                <img src="{{ asset('storage/' . $post->thumbnail) }}" alt="Blog Post illustration" class="lg:rounded-xl w-full">
+                <img src="{{ asset('storage/' . $post->thumbnail) }}" alt="Blog Post illustration" class="lg:rounded-xl w-full max-w-[400px]">
             </a>
         </div>
 

--- a/resources/views/components/post-featured-card.blade.php
+++ b/resources/views/components/post-featured-card.blade.php
@@ -3,7 +3,7 @@
     <div class="lg:py-6 lg:px-5 lg:flex">
         <div class="flex-1 lg:mr-8">
             <a href="/posts/{{$post->slug}}">
-                <img src="{{ asset('storage/' . $post->thumbnail) }}" alt="Blog Post illustration" class="lg:rounded-xl w-full">
+                <img src="{{ asset('storage/' . $post->thumbnail) }}" alt="Blog Post illustration" class="lg:rounded-xl w-full max-w-[400px]">
             </a>
         </div>
 

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -1,7 +1,7 @@
 <x-layout>
     @include('posts._header')
 
-    <main class="max-w-6xl mx-auto mt-6 mb-10 lg:mt-20 space-y-6">
+    <main class="max-w-4xl mx-auto mt-6 mb-10 lg:mt-20 space-y-6">
 
         @if ($posts->count())
             <x-posts-grid :posts="$posts" />


### PR DESCRIPTION
This commit resizes the post's thumbnail image when creating or editing a post. The resizing is done on the Livewire controllers after the forms are submitted. The resizing is done using the intervention image package. 

I have also changed a few details as it pertains to the layout of posts.  